### PR TITLE
Test

### DIFF
--- a/source/core_json.c
+++ b/source/core_json.c
@@ -1090,9 +1090,8 @@ static JSONStatus_t skipCollection( const char * buf,
                     break;
                 }
 
-                /* If the below condition is true, then the depth is 0 and we
-                 * have reached the end of the collection. */
-                ret = isMatchingBracket_( stack[ depth ], c ) ? JSONSuccess : JSONIllegalDocument;
+                ret = ( ( depth == 0 ) && isMatchingBracket_( stack[ depth ], c ) ) ?
+                      JSONSuccess : JSONIllegalDocument;
                 break;
 
             default:

--- a/source/core_json.c
+++ b/source/core_json.c
@@ -1090,7 +1090,9 @@ static JSONStatus_t skipCollection( const char * buf,
                     break;
                 }
 
-                ret = ( depth == 0 ) ? JSONSuccess : JSONIllegalDocument;
+                /* If the below condition is true, then the depth is 0 and we
+                 * have reached the end of the collection. */
+                ret = isMatchingBracket_( stack[ depth ], c ) ? JSONSuccess : JSONIllegalDocument;
                 break;
 
             default:

--- a/test/unit-test/core_json_utest.c
+++ b/test/unit-test/core_json_utest.c
@@ -176,6 +176,9 @@
 #define MISMATCHED_BRACKETS3                               "{\"foo\":[\"bar\",\"xyz\"]]"
 #define MISMATCHED_BRACKETS3_LENGTH                        ( sizeof( MISMATCHED_BRACKETS3 ) - 1 )
 
+#define MISMATCHED_BRACKETS4                               "[\"foo\",\"bar\",\"xyz\"}"
+#define MISMATCHED_BRACKETS4_LENGTH                        ( sizeof( MISMATCHED_BRACKETS4 ) - 1 )
+
 #define INCORRECT_OBJECT_SEPARATOR                         "{\"foo\": \"bar\"; \"bar\": \"foo\"}"
 #define INCORRECT_OBJECT_SEPARATOR_LENGTH                  ( sizeof( INCORRECT_OBJECT_SEPARATOR ) - 1 )
 
@@ -625,6 +628,10 @@ void test_JSON_Validate_Illegal_Documents( void )
 
     jsonStatus = JSON_Validate( MISMATCHED_BRACKETS3,
                                 MISMATCHED_BRACKETS3_LENGTH );
+    TEST_ASSERT_EQUAL( JSONIllegalDocument, jsonStatus );
+
+    jsonStatus = JSON_Validate( MISMATCHED_BRACKETS4,
+                                MISMATCHED_BRACKETS4_LENGTH );
     TEST_ASSERT_EQUAL( JSONIllegalDocument, jsonStatus );
 
     jsonStatus = JSON_Validate( NUL_ESCAPE, NUL_ESCAPE_LENGTH );

--- a/test/unit-test/core_json_utest.c
+++ b/test/unit-test/core_json_utest.c
@@ -1252,7 +1252,7 @@ void test_JSON_Search_Illegal_Documents( void )
                               COMPLETE_QUERY_KEY_LENGTH,
                               &outValue,
                               &outValueLength );
-    TEST_ASSERT_EQUAL( JSONSuccess, jsonStatus );
+    TEST_ASSERT_EQUAL( JSONNotFound, jsonStatus );
 
     jsonStatus = JSON_Search( LETTER_AS_EXPONENT,
                               LETTER_AS_EXPONENT_LENGTH,

--- a/test/unit-test/core_json_utest.c
+++ b/test/unit-test/core_json_utest.c
@@ -171,7 +171,10 @@
 #define MISMATCHED_BRACKETS_LENGTH                         ( sizeof( MISMATCHED_BRACKETS ) - 1 )
 
 #define MISMATCHED_BRACKETS2                               "{\"foo\":[\"bar\",\"xyz\"}}"
-#define MISMATCHED_BRACKETS2_LENGTH                        ( sizeof( MISMATCHED_BRACKETS ) - 1 )
+#define MISMATCHED_BRACKETS2_LENGTH                        ( sizeof( MISMATCHED_BRACKETS2 ) - 1 )
+
+#define MISMATCHED_BRACKETS3                               "{\"foo\":[\"bar\",\"xyz\"]]"
+#define MISMATCHED_BRACKETS3_LENGTH                        ( sizeof( MISMATCHED_BRACKETS3 ) - 1 )
 
 #define INCORRECT_OBJECT_SEPARATOR                         "{\"foo\": \"bar\"; \"bar\": \"foo\"}"
 #define INCORRECT_OBJECT_SEPARATOR_LENGTH                  ( sizeof( INCORRECT_OBJECT_SEPARATOR ) - 1 )
@@ -618,6 +621,10 @@ void test_JSON_Validate_Illegal_Documents( void )
 
     jsonStatus = JSON_Validate( MISMATCHED_BRACKETS2,
                                 MISMATCHED_BRACKETS2_LENGTH );
+    TEST_ASSERT_EQUAL( JSONIllegalDocument, jsonStatus );
+
+    jsonStatus = JSON_Validate( MISMATCHED_BRACKETS3,
+                                MISMATCHED_BRACKETS3_LENGTH );
     TEST_ASSERT_EQUAL( JSONIllegalDocument, jsonStatus );
 
     jsonStatus = JSON_Validate( NUL_ESCAPE, NUL_ESCAPE_LENGTH );


### PR DESCRIPTION
Fixes an issue where an invalid JSON with mismatched outermost brackets may be marked as valid, e.g. `"{ \"Hello\": \"World\" ]"`. This is due to the validator [not checking for matching brackets](https://github.com/FreeRTOS/coreJSON/blob/db619affc197f90d769ba2056d63bcc9d691fc82/source/core_json.c#L1093) at the outermost depth.

While fixing this, I also found a bug in the unit tests, where a case that was supposed to error was [checking for success instead](https://github.com/FreeRTOS/coreJSON/blob/db619affc197f90d769ba2056d63bcc9d691fc82/test/unit-test/core_json_utest.c#L1248). If that test case were to have been corrected, then this bug would've been caught.

It was a little frustrating running the unit tests on my computer, since they don't compile with gcc 10 or later. I had to pass in the cmake flag `-DCMAKE_C_FLAGS="-fcommon"` in order to run them, which I couldn't find documented here. This hasn't been caught by GitHub Actions since Actions is using `ubuntu-latest`, which is still 20.04 and comes with an older version of gcc.